### PR TITLE
Improve prettyjson docs and add basic test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eberle1080/slog-pretty-json
 
-go 1.24.2
+go 1.22
 
 require (
 	github.com/alecthomas/chroma v0.10.0

--- a/slog/prettyjson/doc.go
+++ b/slog/prettyjson/doc.go
@@ -1,0 +1,4 @@
+// Package prettyjson provides a slog.Handler that outputs formatted JSON.
+// It wraps slog.JSONHandler and optionally applies syntax highlighting using
+// github.com/alecthomas/chroma.
+package prettyjson

--- a/slog/prettyjson/errors.go
+++ b/slog/prettyjson/errors.go
@@ -2,4 +2,5 @@ package prettyjson
 
 import "errors"
 
+// ErrCreationFailed is returned when the handler cannot be constructed.
 var ErrCreationFailed = errors.New("failed to create prettyjson handler")

--- a/slog/prettyjson/handler_test.go
+++ b/slog/prettyjson/handler_test.go
@@ -1,0 +1,27 @@
+package prettyjson
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+func TestHandlerWritesOutput(t *testing.T) {
+	var buf bytes.Buffer
+	h, err := NewHandler(&buf, nil)
+	if err != nil {
+		t.Fatalf("new handler: %v", err)
+	}
+
+	r := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+	r.AddAttrs(slog.String("k", "v"))
+
+	if err := h.Handle(context.Background(), r); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("no output written")
+	}
+}

--- a/slog/prettyjson/options.go
+++ b/slog/prettyjson/options.go
@@ -4,7 +4,7 @@ import "log/slog"
 
 type Option func(*options)
 
-// WithStyle sets the style.
+// WithStyle sets the chroma style used for colorizing JSON.
 // See https://xyproto.github.io/splash/docs/
 func WithStyle(style string) Option {
 	return func(opts *options) {
@@ -12,24 +12,28 @@ func WithStyle(style string) Option {
 	}
 }
 
+// WithAttrs adds the provided attributes to every record handled.
 func WithAttrs(attrs []slog.Attr) Option {
 	return func(opts *options) {
 		opts.attrs = attrs
 	}
 }
 
+// WithGroup adds a slog group around all records.
 func WithGroup(group string) Option {
 	return func(opts *options) {
 		opts.groups = append(opts.groups, group)
 	}
 }
 
+// WithPretty toggles prettifying of the JSON output.
 func WithPretty(pretty bool) Option {
 	return func(opts *options) {
 		opts.pretty = pretty
 	}
 }
 
+// WithColor toggles ANSI color output.
 func WithColor(color bool) Option {
 	return func(opts *options) {
 		opts.color = color


### PR DESCRIPTION
## Summary
- fix Go version in `go.mod`
- document the `prettyjson` package and exported APIs
- replace unprofessional comment and use idiomatic mutex name
- add a minimal unit test to ensure the handler writes output

## Testing
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684b6702f5a4832aa3418931afccedd1